### PR TITLE
unhide error message from jsonRpcSend

### DIFF
--- a/jsonapi.go
+++ b/jsonapi.go
@@ -708,7 +708,7 @@ func RpcCommand(user string, password string, server string, message []byte) (Re
 	}
 	resp, err := jsonRpcSend(user, password, server, message)
 	if err != nil {
-		err := fmt.Errorf("Error Sending json message.")
+		err := fmt.Errorf("Error sending json message: "+err.Error())
 		return result, err
 	}
 	body, err := GetRaw(resp.Body)

--- a/jsonfxns.go
+++ b/jsonfxns.go
@@ -34,9 +34,7 @@ func MarshallAndSend(rawReply Reply, w io.Writer) (string, error) {
 func jsonRpcSend(user string, password string, server string, message []byte) (*http.Response, error) {
 	resp, err := http.Post("http://"+user+":"+password+"@"+server,
 		"application/json", bytes.NewBuffer(message))
-	if err != nil {
-		err = fmt.Errorf("Error Sending json message.")
-	}
+
 	return resp, err
 }
 


### PR DESCRIPTION
Currently jsonRpcSend swallows error messages and returns an unhelpful error message instead. This commit changes that by returning the real error to the caller.
