### PR TITLE
don't unmarshall http error response

### DIFF
--- a/jsonapi.go
+++ b/jsonapi.go
@@ -8,7 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 )
+
+// BadStatusCode describes a HTTP error when a response has non-200 status code
+type BadStatusCode int
+
+func (e BadStatusCode) Error() string {
+	status := int(e)
+	return fmt.Sprintf("http bad status: %d %s", status, http.StatusText(status))
+}
 
 // ErrIncorrectArgTypes describes an error where the wrong argument types
 // are present.
@@ -710,6 +719,9 @@ func rpcRawCommand(user string, password string, server string,
 	if err != nil {
 		err := fmt.Errorf("error sending json message: " + err.Error())
 		return result, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, BadStatusCode(resp.StatusCode)
 	}
 	result, err = GetRaw(resp.Body)
 	if err != nil {

--- a/jsonresults.go
+++ b/jsonresults.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 )
 
 // BlockResult models the data from the getblock command when the verbose flag
@@ -446,11 +445,6 @@ func ReadResultCmd(cmd string, message []byte) (Reply, error) {
 	var objmap map[string]json.RawMessage
 	err = json.Unmarshal(message, &objmap)
 	if err != nil {
-		if strings.Contains(string(message), "401 Unauthorized.") {
-			err = fmt.Errorf("authentication error")
-		} else {
-			err = fmt.Errorf("error unmarshalling json reply: %v", err)
-		}
 		return result, err
 	}
 	// Take care of the parts that are the same for all replies.


### PR DESCRIPTION
e.g 429 Too many requests is parsed and a cryptic error message is shown:

```
rpcCommand: error reading json message: error unmarshalling json reply: invalid character 'T' after top-level value
```

instead, don't parse unless the response code indicates success
