### PR TITLE
Add new logging subsystem ADXR to debuglevel help

### DIFF
--- a/cmdhelp.go
+++ b/cmdhelp.go
@@ -54,6 +54,7 @@ Alternatively levelspec  may be a specification of the form:
 <subsystem>=<level>,<subsystem2>=<level2>
 Where the valid subsystem names are:
 AMGR,
+ADXR,
 BCDB,
 BMGR,
 BTCD,


### PR DESCRIPTION
This adds the new subsystem introduced in btcsuite/btcd#205 to the `help` output for the `debuglevel` command. 